### PR TITLE
Use `mv` in build scripts instead of `cp`

### DIFF
--- a/build-scripts/build-with-cabal-new.sh
+++ b/build-scripts/build-with-cabal-new.sh
@@ -27,4 +27,4 @@ cabal new-configure \
 cabal new-build
 
 find dist-newstyle -type f -executable -name $EXE_NAME \
-     -exec cp '{}' $output_file ';'
+     -exec mv -u '{}' $output_file ';'

--- a/build-scripts/build-with-cabal-sandbox.sh
+++ b/build-scripts/build-with-cabal-sandbox.sh
@@ -28,4 +28,4 @@ cabal configure --enable-optimization \
 cabal install --only-dependencies
 cabal build
 
-cp dist/build/$EXE_NAME/$EXE_NAME $output_file
+mv -u dist/build/$EXE_NAME/$EXE_NAME $output_file

--- a/build-scripts/build-with-stack.sh
+++ b/build-scripts/build-with-stack.sh
@@ -20,4 +20,4 @@ output_file=$1; shift
 ################################################################################
 cd $SRC_DIR
 stack build
-cp `stack path --dist-dir`/build/$EXE_NAME/$EXE_NAME $output_file
+mv -u `stack path --dist-dir`/build/$EXE_NAME/$EXE_NAME $output_file


### PR DESCRIPTION
`cp` does not unlink a file it is overwriting, which prevents
it from replacing a running xmonad binary with a new one.
`mv` *does* unlink first, so use that.