### PR TITLE
Add X11 configuration instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,19 @@ since the last time it was compiled.
 
 ### Building All Dependencies with a Specific Configuration File
 
-Using [stack][], building everything is quite easy:
+When using either [stack][] or [cabal][], the [X11][] package needs to be
+configured first:
+
+    $ cd x11
+    $ autoreconf
+    $ cd ..
+
+If using [stack][], building everything is quite easy:
 
     $ stack setup
     $ stack build
 
-Using a recent enough [cabal][], building everything is even easier:
+If using a recent enough [cabal][], building everything is even easier:
 
     $ cabal new-build
 
@@ -117,3 +124,4 @@ XMonad in another xorg session using [Xephyr][]:
 [stack]: https://docs.haskellstack.org/en/stable/README/
 [cabal]: http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html
 [xephyr]: https://www.freedesktop.org/wiki/Software/Xephyr/
+[X11]: https://github.com/xmonad/X11


### PR DESCRIPTION
I got burned by this the first few times I tried to use this repo.

I know it mentions it in the error text if you forget the `autoreconf` step, but it's a bit of a wall of text and I figure it's better to explicitly mention it needs doing.