### PR TITLE
XMonad Build Scripts should forcecully copy build result.

### DIFF
--- a/build-scripts/build-with-cabal-new.sh
+++ b/build-scripts/build-with-cabal-new.sh
@@ -27,4 +27,4 @@ cabal new-configure \
 cabal new-build
 
 find dist-newstyle -type f -executable -name $EXE_NAME \
-     -exec mv -u '{}' $output_file ';'
+     -exec cp -uf '{}' $output_file ';'

--- a/build-scripts/build-with-cabal-sandbox.sh
+++ b/build-scripts/build-with-cabal-sandbox.sh
@@ -28,4 +28,4 @@ cabal configure --enable-optimization \
 cabal install --only-dependencies
 cabal build
 
-mv -u dist/build/$EXE_NAME/$EXE_NAME $output_file
+cp -uf dist/build/$EXE_NAME/$EXE_NAME $output_file

--- a/build-scripts/build-with-stack.sh
+++ b/build-scripts/build-with-stack.sh
@@ -20,4 +20,4 @@ output_file=$1; shift
 ################################################################################
 cd $SRC_DIR
 stack build
-mv -u `stack path --dist-dir`/build/$EXE_NAME/$EXE_NAME $output_file
+cp -uf `stack exec which $EXE_NAME` $output_file


### PR DESCRIPTION
build script examples use `mv -u` which breaks subsequence builds
because previous runs displaced the build result.

`cp -u` fails because the destination is already being used by
xmonad process.

`cp -uf` is the only thing that makes sense for now.

Let `--force` guide you.