### PR TITLE
Improve build-with-stack.sh , addressing issues in xmonad#102

### DIFF
--- a/build-scripts/build-with-stack.sh
+++ b/build-scripts/build-with-stack.sh
@@ -1,23 +1,23 @@
 #!/bin/sh -eu
 
 ################################################################################
-# Edit this file and then rename it to ~/.xmonad/build
+# Edit the following constants and then rename this script to ~/.xmonad/build
 
-################################################################################
 # The directory holding your source code and stack.yaml file:
 SRC_DIR=~/develop/oss/xmonad-testing
 
-################################################################################
 # The name of the executable produced by stack.  This comes from the
-# executable section of your Cabal file.
+# executable section of your *.cabal or package.yaml file.
 EXE_NAME=xmonad-testing
 
 ################################################################################
-# This script will be given a single argument, the path to the
-# executable it should produce.
-output_file=$1; shift
 
-################################################################################
+# Unset STACK_YAML, to ensure that $SRC_DIR/stack.yaml is used.
+unset STACK_YAML
+
+# Do the build.
 cd $SRC_DIR
 stack build
-mv -u `stack path --dist-dir`/build/$EXE_NAME/$EXE_NAME $output_file
+
+# Create a hard link at the requested destination, replacing any existing one.
+ln -f -T $(stack exec -- which $EXE_NAME) $1


### PR DESCRIPTION
* Creates a hardlink instead of using mv. This is better than moving the result
  exe because stack expects to find the binary in the dist directory - moving it
  will cause redundant invocation of Cabal copy. Also the creation of the
  hardlink ignores if it already exists - see discussion in xmonad#102

* Uses "stack exec -- which $EXE_NAME" instead of munging "stack path", fixing
  xmonad#102. I believe that the munging no longer works due to Cabal changes
  related to per-component build.