### PR TITLE
Upgrade to current stable stack and xmonad

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.6
+resolver: lts-11.8
 
 nix:
   enable: false
@@ -13,5 +13,3 @@ packages:
 
 extra-deps:
   - X11-xft-0.3.1
-  - directory-1.2.7.1
-  - xmobar-0.24.3


### PR DESCRIPTION
Drops the pinned version of directory and xmobar as well.

I'm not sure how xmonad-testing is kept up to date, but I just noticed that the versions are quite old and could use a bump up. Compiles for me and I'm using this config to run my desktop as of now. 